### PR TITLE
Better Today Extension

### DIFF
--- a/Classes/Extensions/UIColor+ColorScheme.swift
+++ b/Classes/Extensions/UIColor+ColorScheme.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 CUAppDev. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 extension UIColor {
     

--- a/Eatery.xcodeproj/project.pbxproj
+++ b/Eatery.xcodeproj/project.pbxproj
@@ -7,15 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1DDD3B9A1BE9F4B7005B1D1E /* DiningStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAA912A51BE69E5F003475A8 /* DiningStack.framework */; };
 		423AB0341BE99120009C9841 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D18D9C5B1BAF2BF100C9D95D /* SwiftyJSON.framework */; };
 		4283B3711BE6A17C003DE22E /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4283B3701BE6A17C003DE22E /* NotificationCenter.framework */; };
 		4283B3771BE6A17C003DE22E /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4283B3751BE6A17C003DE22E /* MainInterface.storyboard */; };
 		4283B37B1BE6A17C003DE22E /* Today Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4283B36F1BE6A17C003DE22E /* Today Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4283B3831BE6A1F9003DE22E /* TodayExtensionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B3821BE6A1F9003DE22E /* TodayExtensionTableViewController.swift */; };
-		4283B3841BE6A32F003DE22E /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497ACD1B64AA1800AC1C6C /* DataManager.swift */; };
-		4283B3851BE6A3C2003DE22E /* Eatery.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AD91B64AA1800AC1C6C /* Eatery.swift */; };
-		4283B3861BE6A3C5003DE22E /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497ADB1B64AA1800AC1C6C /* MenuItem.swift */; };
-		4283B3871BE6A3C7003DE22E /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACCE0881BC1A61800E54408 /* Event.swift */; };
 		4283B3891BE6A4A4003DE22E /* LiteEatery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B3881BE6A4A4003DE22E /* LiteEatery.swift */; };
 		4283B38B1BE6A4AF003DE22E /* LiteEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B38A1BE6A4AF003DE22E /* LiteEvent.swift */; };
 		4283B38E1BE6A5E5003DE22E /* NoFavoritesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B38C1BE6A5E5003DE22E /* NoFavoritesTableViewCell.swift */; };
@@ -24,10 +21,7 @@
 		4283B3931BE6A6B2003DE22E /* TodayExtensionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4283B3911BE6A6B2003DE22E /* TodayExtensionTableViewCell.xib */; };
 		4283B3951BE6A6DC003DE22E /* CircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B3941BE6A6DC003DE22E /* CircleView.swift */; };
 		4283B3961BE6A70F003DE22E /* UIColor+ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AF11B64AA1800AC1C6C /* UIColor+ColorScheme.swift */; };
-		4283B3971BE6AA8D003DE22E /* EateryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AD41B64AA1800AC1C6C /* EateryData.swift */; };
-		4283B3981BE6AAE8003DE22E /* EateryIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AD51B64AA1800AC1C6C /* EateryIDs.swift */; };
-		4283B3991BE6AAEC003DE22E /* GeneralMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AD61B64AA1800AC1C6C /* GeneralMenus.swift */; };
-		745255E5F75E8B1EAC4E54EE /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 009907E8EA5C64DC3A183B9D /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		745255E5F75E8B1EAC4E54EE /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 009907E8EA5C64DC3A183B9D /* Pods.framework */; };
 		95434FB71BD8699F003612DB /* ADScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95434F951BD8699F003612DB /* ADScreenCapture.swift */; };
 		95434FB81BD8699F003612DB /* _FBTweakArrayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 95434F981BD8699F003612DB /* _FBTweakArrayViewController.m */; };
 		95434FB91BD8699F003612DB /* _FBTweakBindObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 95434F9A1BD8699F003612DB /* _FBTweakBindObserver.m */; };
@@ -137,36 +131,19 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		FAA912A41BE69E5F003475A8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = FAA9129E1BE69E5F003475A8 /* DiningStack.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FAF5CE731BE19C6E00C49EDE;
-			remoteInfo = DiningStack;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		FAA912A91BE69E8C003475A8 /* Copy Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				FAA912AB1BE69E96003475A8 /* DiningStack.framework in Copy Frameworks */,
-			);
-			name = "Copy Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
-/* Begin PBXContainerItemProxy section */
 		4283B3791BE6A17C003DE22E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C007CAB719E1BEAC00E3BD46 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 4283B36E1BE6A17C003DE22E;
 			remoteInfo = "Today Extension";
+		};
+		FAA912A41BE69E5F003475A8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FAA9129E1BE69E5F003475A8 /* DiningStack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FAF5CE731BE19C6E00C49EDE;
+			remoteInfo = DiningStack;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -180,6 +157,17 @@
 				4283B37B1BE6A17C003DE22E /* Today Extension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FAA912A91BE69E8C003475A8 /* Copy Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				FAA912AB1BE69E96003475A8 /* DiningStack.framework in Copy Frameworks */,
+			);
+			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -342,6 +330,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1DDD3B9A1BE9F4B7005B1D1E /* DiningStack.framework in Frameworks */,
 				423AB0341BE99120009C9841 /* SwiftyJSON.framework in Frameworks */,
 				4283B3711BE6A17C003DE22E /* NotificationCenter.framework in Frameworks */,
 			);
@@ -741,7 +730,6 @@
 				TargetAttributes = {
 					4283B36E1BE6A17C003DE22E = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = 4M3BV3H234;
 					};
 					C007CABE19E1BEAC00E3BD46 = {
 						CreatedOnToolsVersion = 6.0.1;
@@ -919,20 +907,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4283B3981BE6AAE8003DE22E /* EateryIDs.swift in Sources */,
-				4283B3851BE6A3C2003DE22E /* Eatery.swift in Sources */,
 				4283B3921BE6A6B2003DE22E /* TodayExtensionTableViewCell.swift in Sources */,
 				4283B3961BE6A70F003DE22E /* UIColor+ColorScheme.swift in Sources */,
 				4283B3891BE6A4A4003DE22E /* LiteEatery.swift in Sources */,
-				4283B3861BE6A3C5003DE22E /* MenuItem.swift in Sources */,
 				4283B38B1BE6A4AF003DE22E /* LiteEvent.swift in Sources */,
 				4283B38E1BE6A5E5003DE22E /* NoFavoritesTableViewCell.swift in Sources */,
-				4283B3971BE6AA8D003DE22E /* EateryData.swift in Sources */,
 				4283B3951BE6A6DC003DE22E /* CircleView.swift in Sources */,
 				4283B3831BE6A1F9003DE22E /* TodayExtensionTableViewController.swift in Sources */,
-				4283B3841BE6A32F003DE22E /* DataManager.swift in Sources */,
-				4283B3871BE6A3C7003DE22E /* Event.swift in Sources */,
-				4283B3991BE6AAEC003DE22E /* GeneralMenus.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1146,7 +1127,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/Eatery.xcodeproj/project.pbxproj
+++ b/Eatery.xcodeproj/project.pbxproj
@@ -7,10 +7,26 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		423AB0341BE99120009C9841 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D18D9C5B1BAF2BF100C9D95D /* SwiftyJSON.framework */; };
 		4283B3711BE6A17C003DE22E /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4283B3701BE6A17C003DE22E /* NotificationCenter.framework */; };
 		4283B3771BE6A17C003DE22E /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4283B3751BE6A17C003DE22E /* MainInterface.storyboard */; };
 		4283B37B1BE6A17C003DE22E /* Today Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4283B36F1BE6A17C003DE22E /* Today Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4283B3831BE6A1F9003DE22E /* TodayExtensionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B3821BE6A1F9003DE22E /* TodayExtensionTableViewController.swift */; };
+		4283B3841BE6A32F003DE22E /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497ACD1B64AA1800AC1C6C /* DataManager.swift */; };
+		4283B3851BE6A3C2003DE22E /* Eatery.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AD91B64AA1800AC1C6C /* Eatery.swift */; };
+		4283B3861BE6A3C5003DE22E /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497ADB1B64AA1800AC1C6C /* MenuItem.swift */; };
+		4283B3871BE6A3C7003DE22E /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACCE0881BC1A61800E54408 /* Event.swift */; };
+		4283B3891BE6A4A4003DE22E /* LiteEatery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B3881BE6A4A4003DE22E /* LiteEatery.swift */; };
+		4283B38B1BE6A4AF003DE22E /* LiteEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B38A1BE6A4AF003DE22E /* LiteEvent.swift */; };
+		4283B38E1BE6A5E5003DE22E /* NoFavoritesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B38C1BE6A5E5003DE22E /* NoFavoritesTableViewCell.swift */; };
+		4283B38F1BE6A5E5003DE22E /* NoFavoritesTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4283B38D1BE6A5E5003DE22E /* NoFavoritesTableViewCell.xib */; };
+		4283B3921BE6A6B2003DE22E /* TodayExtensionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B3901BE6A6B2003DE22E /* TodayExtensionTableViewCell.swift */; };
+		4283B3931BE6A6B2003DE22E /* TodayExtensionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4283B3911BE6A6B2003DE22E /* TodayExtensionTableViewCell.xib */; };
+		4283B3951BE6A6DC003DE22E /* CircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B3941BE6A6DC003DE22E /* CircleView.swift */; };
+		4283B3961BE6A70F003DE22E /* UIColor+ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AF11B64AA1800AC1C6C /* UIColor+ColorScheme.swift */; };
+		4283B3971BE6AA8D003DE22E /* EateryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AD41B64AA1800AC1C6C /* EateryData.swift */; };
+		4283B3981BE6AAE8003DE22E /* EateryIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AD51B64AA1800AC1C6C /* EateryIDs.swift */; };
+		4283B3991BE6AAEC003DE22E /* GeneralMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AD61B64AA1800AC1C6C /* GeneralMenus.swift */; };
 		745255E5F75E8B1EAC4E54EE /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 009907E8EA5C64DC3A183B9D /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		95434FB71BD8699F003612DB /* ADScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95434F951BD8699F003612DB /* ADScreenCapture.swift */; };
 		95434FB81BD8699F003612DB /* _FBTweakArrayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 95434F981BD8699F003612DB /* _FBTweakArrayViewController.m */; };
@@ -175,6 +191,13 @@
 		4283B3761BE6A17C003DE22E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		4283B3781BE6A17C003DE22E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4283B3821BE6A1F9003DE22E /* TodayExtensionTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodayExtensionTableViewController.swift; sourceTree = "<group>"; };
+		4283B3881BE6A4A4003DE22E /* LiteEatery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiteEatery.swift; sourceTree = "<group>"; };
+		4283B38A1BE6A4AF003DE22E /* LiteEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiteEvent.swift; sourceTree = "<group>"; };
+		4283B38C1BE6A5E5003DE22E /* NoFavoritesTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoFavoritesTableViewCell.swift; sourceTree = "<group>"; };
+		4283B38D1BE6A5E5003DE22E /* NoFavoritesTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoFavoritesTableViewCell.xib; sourceTree = "<group>"; };
+		4283B3901BE6A6B2003DE22E /* TodayExtensionTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodayExtensionTableViewCell.swift; sourceTree = "<group>"; };
+		4283B3911BE6A6B2003DE22E /* TodayExtensionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TodayExtensionTableViewCell.xib; sourceTree = "<group>"; };
+		4283B3941BE6A6DC003DE22E /* CircleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircleView.swift; sourceTree = "<group>"; };
 		95434F951BD8699F003612DB /* ADScreenCapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ADScreenCapture.swift; sourceTree = "<group>"; };
 		95434F971BD8699F003612DB /* _FBTweakArrayViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _FBTweakArrayViewController.h; sourceTree = "<group>"; };
 		95434F981BD8699F003612DB /* _FBTweakArrayViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _FBTweakArrayViewController.m; sourceTree = "<group>"; };
@@ -319,6 +342,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				423AB0341BE99120009C9841 /* SwiftyJSON.framework in Frameworks */,
 				4283B3711BE6A17C003DE22E /* NotificationCenter.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -339,6 +363,13 @@
 			isa = PBXGroup;
 			children = (
 				4283B3821BE6A1F9003DE22E /* TodayExtensionTableViewController.swift */,
+				4283B3901BE6A6B2003DE22E /* TodayExtensionTableViewCell.swift */,
+				4283B3911BE6A6B2003DE22E /* TodayExtensionTableViewCell.xib */,
+				4283B3941BE6A6DC003DE22E /* CircleView.swift */,
+				4283B38C1BE6A5E5003DE22E /* NoFavoritesTableViewCell.swift */,
+				4283B38D1BE6A5E5003DE22E /* NoFavoritesTableViewCell.xib */,
+				4283B3881BE6A4A4003DE22E /* LiteEatery.swift */,
+				4283B38A1BE6A4AF003DE22E /* LiteEvent.swift */,
 				4283B3751BE6A17C003DE22E /* MainInterface.storyboard */,
 				4283B3781BE6A17C003DE22E /* Info.plist */,
 			);
@@ -758,6 +789,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4283B38F1BE6A5E5003DE22E /* NoFavoritesTableViewCell.xib in Resources */,
+				4283B3931BE6A6B2003DE22E /* TodayExtensionTableViewCell.xib in Resources */,
 				4283B3771BE6A17C003DE22E /* MainInterface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -886,7 +919,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4283B3981BE6AAE8003DE22E /* EateryIDs.swift in Sources */,
+				4283B3851BE6A3C2003DE22E /* Eatery.swift in Sources */,
+				4283B3921BE6A6B2003DE22E /* TodayExtensionTableViewCell.swift in Sources */,
+				4283B3961BE6A70F003DE22E /* UIColor+ColorScheme.swift in Sources */,
+				4283B3891BE6A4A4003DE22E /* LiteEatery.swift in Sources */,
+				4283B3861BE6A3C5003DE22E /* MenuItem.swift in Sources */,
+				4283B38B1BE6A4AF003DE22E /* LiteEvent.swift in Sources */,
+				4283B38E1BE6A5E5003DE22E /* NoFavoritesTableViewCell.swift in Sources */,
+				4283B3971BE6AA8D003DE22E /* EateryData.swift in Sources */,
+				4283B3951BE6A6DC003DE22E /* CircleView.swift in Sources */,
 				4283B3831BE6A1F9003DE22E /* TodayExtensionTableViewController.swift in Sources */,
+				4283B3841BE6A32F003DE22E /* DataManager.swift in Sources */,
+				4283B3871BE6A3C7003DE22E /* Event.swift in Sources */,
+				4283B3991BE6AAEC003DE22E /* GeneralMenus.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -975,6 +1021,10 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Today Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
@@ -1008,6 +1058,10 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1051,6 +1105,10 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1094,6 +1152,10 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1375,6 +1437,7 @@
 				4283B37F1BE6A17C003DE22E /* App Store */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
 		};
 		C007CABA19E1BEAC00E3BD46 /* Build configuration list for PBXProject "Eatery" */ = {
 			isa = XCConfigurationList;

--- a/Eatery.xcodeproj/project.pbxproj
+++ b/Eatery.xcodeproj/project.pbxproj
@@ -7,7 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		745255E5F75E8B1EAC4E54EE /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 009907E8EA5C64DC3A183B9D /* Pods.framework */; };
+		4283B3711BE6A17C003DE22E /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4283B3701BE6A17C003DE22E /* NotificationCenter.framework */; };
+		4283B3771BE6A17C003DE22E /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4283B3751BE6A17C003DE22E /* MainInterface.storyboard */; };
+		4283B37B1BE6A17C003DE22E /* Today Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4283B36F1BE6A17C003DE22E /* Today Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4283B3831BE6A1F9003DE22E /* TodayExtensionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4283B3821BE6A1F9003DE22E /* TodayExtensionTableViewController.swift */; };
+		745255E5F75E8B1EAC4E54EE /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 009907E8EA5C64DC3A183B9D /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		95434FB71BD8699F003612DB /* ADScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95434F951BD8699F003612DB /* ADScreenCapture.swift */; };
 		95434FB81BD8699F003612DB /* _FBTweakArrayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 95434F981BD8699F003612DB /* _FBTweakArrayViewController.m */; };
 		95434FB91BD8699F003612DB /* _FBTweakBindObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 95434F9A1BD8699F003612DB /* _FBTweakBindObserver.m */; };
@@ -140,8 +144,37 @@
 		};
 /* End PBXCopyFilesBuildPhase section */
 
+/* Begin PBXContainerItemProxy section */
+		4283B3791BE6A17C003DE22E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C007CAB719E1BEAC00E3BD46 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4283B36E1BE6A17C003DE22E;
+			remoteInfo = "Today Extension";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		4283B3811BE6A17C003DE22E /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				4283B37B1BE6A17C003DE22E /* Today Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		009907E8EA5C64DC3A183B9D /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4283B36F1BE6A17C003DE22E /* Today Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Today Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4283B3701BE6A17C003DE22E /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		4283B3761BE6A17C003DE22E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		4283B3781BE6A17C003DE22E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4283B3821BE6A1F9003DE22E /* TodayExtensionTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodayExtensionTableViewController.swift; sourceTree = "<group>"; };
 		95434F951BD8699F003612DB /* ADScreenCapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ADScreenCapture.swift; sourceTree = "<group>"; };
 		95434F971BD8699F003612DB /* _FBTweakArrayViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _FBTweakArrayViewController.h; sourceTree = "<group>"; };
 		95434F981BD8699F003612DB /* _FBTweakArrayViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _FBTweakArrayViewController.m; sourceTree = "<group>"; };
@@ -282,6 +315,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4283B36C1BE6A17C003DE22E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4283B3711BE6A17C003DE22E /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C007CABC19E1BEAC00E3BD46 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -294,6 +335,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4283B3721BE6A17C003DE22E /* Today Extension */ = {
+			isa = PBXGroup;
+			children = (
+				4283B3821BE6A1F9003DE22E /* TodayExtensionTableViewController.swift */,
+				4283B3751BE6A17C003DE22E /* MainInterface.storyboard */,
+				4283B3781BE6A17C003DE22E /* Info.plist */,
+			);
+			path = "Today Extension";
+			sourceTree = "<group>";
+		};
 		95434F941BD8699F003612DB /* Tools */ = {
 			isa = PBXGroup;
 			children = (
@@ -361,6 +412,7 @@
 				C0497ACA1B64AA1800AC1C6C /* Classes */,
 				C0497BC11B64AB4100AC1C6C /* Other-Sources */,
 				C0497B1D1B64AA3800AC1C6C /* Resources */,
+				4283B3721BE6A17C003DE22E /* Today Extension */,
 				C01E03FA19E5C4AD0050E8C7 /* Frameworks */,
 				C007CAC019E1BEAC00E3BD46 /* Products */,
 				9B4931655E89F604CB150CD0 /* Pods */,
@@ -371,6 +423,7 @@
 			isa = PBXGroup;
 			children = (
 				C007CABF19E1BEAC00E3BD46 /* Eatery.app */,
+				4283B36F1BE6A17C003DE22E /* Today Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -382,6 +435,7 @@
 				D18D9C5B1BAF2BF100C9D95D /* SwiftyJSON.framework */,
 				D18D9C591BAF2B5200C9D95D /* Analytics.framework */,
 				009907E8EA5C64DC3A183B9D /* Pods.framework */,
+				4283B3701BE6A17C003DE22E /* NotificationCenter.framework */,
 			);
 			name = Frameworks;
 			path = Eatery;
@@ -603,6 +657,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4283B36E1BE6A17C003DE22E /* Today Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4283B3801BE6A17C003DE22E /* Build configuration list for PBXNativeTarget "Today Extension" */;
+			buildPhases = (
+				4283B36B1BE6A17C003DE22E /* Sources */,
+				4283B36C1BE6A17C003DE22E /* Frameworks */,
+				4283B36D1BE6A17C003DE22E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Today Extension";
+			productName = "Today Extension";
+			productReference = 4283B36F1BE6A17C003DE22E /* Today Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		C007CABE19E1BEAC00E3BD46 /* Eatery */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C007CADE19E1BEAC00E3BD46 /* Build configuration list for PBXNativeTarget "Eatery" */;
@@ -614,10 +685,12 @@
 				E2CFE9C2E9E8D8099684D94E /* Copy Pods Resources */,
 				2529F4D1F6E174E13D3FA0DA /* Embed Pods Frameworks */,
 				FAA912A91BE69E8C003475A8 /* Copy Frameworks */,
+				4283B3811BE6A17C003DE22E /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				4283B37A1BE6A17C003DE22E /* PBXTargetDependency */,
 			);
 			name = Eatery;
 			productName = Eatery;
@@ -631,10 +704,14 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = CUAppDev;
 				TargetAttributes = {
+					4283B36E1BE6A17C003DE22E = {
+						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = 4M3BV3H234;
+					};
 					C007CABE19E1BEAC00E3BD46 = {
 						CreatedOnToolsVersion = 6.0.1;
 					};
@@ -661,6 +738,7 @@
 			projectRoot = "";
 			targets = (
 				C007CABE19E1BEAC00E3BD46 /* Eatery */,
+				4283B36E1BE6A17C003DE22E /* Today Extension */,
 			);
 		};
 /* End PBXProject section */
@@ -676,6 +754,14 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4283B36D1BE6A17C003DE22E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4283B3771BE6A17C003DE22E /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C007CABD19E1BEAC00E3BD46 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -796,6 +882,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4283B36B1BE6A17C003DE22E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4283B3831BE6A1F9003DE22E /* TodayExtensionTableViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C007CABB19E1BEAC00E3BD46 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -847,7 +941,23 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		4283B37A1BE6A17C003DE22E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4283B36E1BE6A17C003DE22E /* Today Extension */;
+			targetProxy = 4283B3791BE6A17C003DE22E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
+		4283B3751BE6A17C003DE22E /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4283B3761BE6A17C003DE22E /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
 		C0497B1E1B64AA3800AC1C6C /* LaunchScreen.xib */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -859,6 +969,151 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		4283B37C1BE6A17C003DE22E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "Today Extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cuappdev.cuad-eatery-debug.Today-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		4283B37D1BE6A17C003DE22E /* External Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Today Extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cuappdev.cuad-eatery-debug.Today-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "External Beta";
+		};
+		4283B37E1BE6A17C003DE22E /* Internal Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Today Extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cuappdev.cuad-eatery-debug.Today-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Internal Beta";
+		};
+		4283B37F1BE6A17C003DE22E /* App Store */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Today Extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cuappdev.cuad-eatery-debug.Today-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "App Store";
+		};
 		C007CADC19E1BEAC00E3BD46 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -912,6 +1167,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 7;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Other-Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -972,6 +1228,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CURRENT_PROJECT_VERSION = 7;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Other-Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -1031,6 +1288,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 7;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Other-Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -1090,6 +1348,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 7;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Other-Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -1107,6 +1366,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4283B3801BE6A17C003DE22E /* Build configuration list for PBXNativeTarget "Today Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4283B37C1BE6A17C003DE22E /* Debug */,
+				4283B37D1BE6A17C003DE22E /* External Beta */,
+				4283B37E1BE6A17C003DE22E /* Internal Beta */,
+				4283B37F1BE6A17C003DE22E /* App Store */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		C007CABA19E1BEAC00E3BD46 /* Build configuration list for PBXProject "Eatery" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Today Extension/Base.lproj/MainInterface.storyboard
+++ b/Today Extension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="M4Y-Lb-cyx">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+    </dependencies>
+    <scenes>
+        <!--Today Extension Table View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" customClass="TodayExtensionTableViewController" customModule="Today_Extension" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Ft6-oW-KC0"/>
+                        <viewControllerLayoutGuide type="bottom" id="FKl-LY-JtV"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="37"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
+                                <rect key="frame" x="20" y="8" width="280" height="21"/>
+                                <animations/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <animations/>
+                        <constraints>
+                            <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="20" symbolic="YES" id="0Q0-KW-PJ6"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe"/>
+                            <constraint firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="20" symbolic="YES" id="mYS-Cv-VNx"/>
+                        </constraints>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <nil key="simulatedStatusBarMetrics"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="37"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="516" y="285"/>
+        </scene>
+    </scenes>
+</document>

--- a/Today Extension/Base.lproj/MainInterface.storyboard
+++ b/Today Extension/Base.lproj/MainInterface.storyboard
@@ -1,48 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="M4Y-Lb-cyx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="xaT-Uu-6WC">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <scenes>
         <!--Today Extension Table View Controller-->
-        <scene sceneID="cwh-vc-ff4">
+        <scene sceneID="ZSq-q7-cPe">
             <objects>
-                <viewController id="M4Y-Lb-cyx" customClass="TodayExtensionTableViewController" customModule="Today_Extension" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="Ft6-oW-KC0"/>
-                        <viewControllerLayoutGuide type="bottom" id="FKl-LY-JtV"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="37"/>
+                <tableViewController id="xaT-Uu-6WC" customClass="TodayExtensionTableViewController" customModule="Today_Extension" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="62" sectionHeaderHeight="28" sectionFooterHeight="28" id="X9H-TC-BMa">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="270"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
-                                <rect key="frame" x="20" y="8" width="280" height="21"/>
-                                <animations/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
                         <animations/>
-                        <constraints>
-                            <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="20" symbolic="YES" id="0Q0-KW-PJ6"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe"/>
-                            <constraint firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="20" symbolic="YES" id="mYS-Cv-VNx"/>
-                        </constraints>
-                    </view>
-                    <extendedEdge key="edgesForExtendedLayout"/>
-                    <nil key="simulatedStatusBarMetrics"/>
-                    <nil key="simulatedTopBarMetrics"/>
-                    <nil key="simulatedBottomBarMetrics"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="todaycell" rowHeight="62" id="I6l-6P-5eQ" customClass="TodayWidgetTableViewCell" customModule="Today_Extension" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="28" width="320" height="62"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="I6l-6P-5eQ" id="VO3-if-0iz">
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="61.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <animations/>
+                                </tableViewCellContentView>
+                                <animations/>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="xaT-Uu-6WC" id="iX6-nX-Awh"/>
+                            <outlet property="delegate" destination="xaT-Uu-6WC" id="3Uu-pB-ALE"/>
+                        </connections>
+                    </tableView>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <size key="freeformSize" width="320" height="37"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                    <size key="freeformSize" width="320" height="270"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dzw-GW-0Da" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="516" y="285"/>
+            <point key="canvasLocation" x="528" y="402"/>
         </scene>
     </scenes>
 </document>

--- a/Today Extension/CircleView.swift
+++ b/Today Extension/CircleView.swift
@@ -1,0 +1,44 @@
+//
+//  CircleView.swift
+//  Eatery
+//
+//  Created by Mark Bryan on 11/1/15.
+//  Copyright © 2015 CUAppDev. All rights reserved.
+//
+
+import UIKit
+
+enum State {
+    case Open
+    case Closed
+}
+
+class CircleView: UIView {
+    
+    var state: State {
+        didSet {
+            switch state {
+            case .Open:
+                backgroundColor = UIColor.openGreen()
+            case .Closed:
+                backgroundColor = UIColor.closedRed()
+            }
+        }
+    }
+    
+    override func layoutSublayersOfLayer(layer: CALayer) {
+        layer.cornerRadius = layer.frame.size.height/2
+        //layer.opacity = 0.4
+    }
+    
+    override init(frame: CGRect) {
+        self.state = .Closed
+        super.init(frame: frame)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        self.state = .Closed
+        super.init(coder: aDecoder)
+    }
+    
+}

--- a/Today Extension/Info.plist
+++ b/Today Extension/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Today Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Today Extension/LiteEatery.swift
+++ b/Today Extension/LiteEatery.swift
@@ -1,0 +1,152 @@
+//
+//  LiteEatery.swift
+//  Eatery
+//
+//  Created by Mark Bryan on 11/1/15.
+//  Copyright © 2015 CUAppDev. All rights reserved.
+//
+
+import UIKit
+import SwiftyJSON
+
+enum OpenStatus {
+    case Open(String)
+    case Closed(String)
+}
+
+func makeKeyFormatter () -> NSDateFormatter {
+    let formatter = NSDateFormatter()
+    formatter.dateFormat = "YYYY-MM-dd"
+    return formatter
+}
+
+func makeShortDateFormatter () -> NSDateFormatter {
+    let formatter = NSDateFormatter()
+    formatter.dateFormat = "h:mma"
+    return formatter
+}
+
+class LiteEatery: NSObject {
+    static let dateKeyFormatter = makeKeyFormatter()
+    static let shortDateFormatter = makeShortDateFormatter()
+    
+    let id: Int
+    let nameShort: String
+    let slug: String
+    
+    private(set) var events: [String: [String: LiteEvent]] = [:]
+    private var _todaysEventsString: String? = nil
+    
+    init(json: JSON) {
+        id    = json[APIKey.Identifier.rawValue].intValue
+        nameShort  = json[APIKey.NameShort.rawValue].stringValue
+        slug  = json[APIKey.Slug.rawValue].stringValue
+        
+        let hoursJSON = json[APIKey.Hours.rawValue]
+        
+        var currentEvents: [String: LiteEvent] = [:]
+        for (_, hour) in hoursJSON {
+            let eventsJSON = hour[APIKey.Events.rawValue]
+            let key        = hour[APIKey.Date.rawValue].stringValue
+            
+            for (_, eventJSON) in eventsJSON {
+                let event = LiteEvent(json: eventJSON)
+                currentEvents[event.desc] = event
+            }
+            
+            events[key] = currentEvents
+        }
+    }
+    
+    // Where onDate means including time
+    func isOpenOnDate(date: NSDate) -> Bool {
+        let yesterday = NSDate(timeInterval: -1 * 24 * 60 * 60, sinceDate: date)
+        
+        for now in [date, yesterday] {
+            let events = eventsOnDate(now)
+            for (_, event) in events {
+                if event.occurringOnDate(date) {
+                    return true
+                }
+            }
+        }
+        
+        return false
+    }
+    
+    func isOpenForDate(date: NSDate) -> Bool {
+        let events = eventsOnDate(date)
+        return events.count != 0
+    }
+    
+    // Tells if eatery is open now
+    func isOpenNow() -> Bool {
+        return isOpenOnDate(NSDate())
+    }
+    
+    func isOpenToday() -> Bool {
+        return isOpenForDate(NSDate())
+    }
+    
+    // Retrieves event instances for a specific day
+    func eventsOnDate(date: NSDate) -> [String: LiteEvent] {
+        let dateString = LiteEatery.dateKeyFormatter.stringFromDate(date)
+        return events[dateString] ?? [:]
+    }
+    
+    // Retrieves the currently active event or the next event for a day/time
+    func activeEventForDate(date: NSDate) -> LiteEvent? {
+        let tomorrow = NSDate(timeInterval: 24 * 60 * 60, sinceDate: date)
+        
+        var timeDifference = DBL_MAX
+        var next: LiteEvent? = nil
+        
+        for now in [date, tomorrow] {
+            let events = eventsOnDate(now)
+            
+            for (_, event) in events {
+                let diff = event.startDate.timeIntervalSince1970 - date.timeIntervalSince1970
+                if event.occurringOnDate(date) {
+                    return event
+                } else if diff < timeDifference && diff > 0 {
+                    timeDifference = diff
+                    next = event
+                }
+            }
+        }
+        
+        return next
+    }
+    
+    // Generates description of eatery for its current state
+    // returns "Opening in x min)" if x <= 60 and is closed"
+    // "Closing in x min) if x <= 60 and is open,
+    // "Closed" if closed and not opening soon,
+    // "Open now" if open and not closing soon
+    // Bool value is either stable or about to change
+    func generateDescriptionOfCurrentState() -> OpenStatus {
+        if isOpenToday() {
+            let activeEvent = activeEventForDate(NSDate())
+            print(activeEvent)
+            if activeEvent!.occurringOnDate(NSDate()) {
+                let minutesTillClose = (Int)(activeEvent!.endDate.timeIntervalSinceNow/Double(60))
+                if minutesTillClose < 30 {
+                    return .Open("Closing in \(minutesTillClose) m")
+                } else {
+                    let timeString = LiteEatery.shortDateFormatter.stringFromDate(activeEvent!.endDate)
+                    return .Open("Closes at \(timeString)")
+                }
+            } else {
+                let minutesTillOpen = (Int)(activeEvent!.startDate.timeIntervalSinceNow/Double(60))
+                if minutesTillOpen < 60 {
+                    return .Closed("Opens in \(minutesTillOpen) m")
+                } else {
+                    let timeString = LiteEatery.shortDateFormatter.stringFromDate(activeEvent!.startDate)
+                    return .Closed("Opens at \(timeString)")
+                }
+            }
+        } else {
+            return .Closed("Closed")
+        }
+    }
+}

--- a/Today Extension/LiteEatery.swift
+++ b/Today Extension/LiteEatery.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import SwiftyJSON
+import DiningStack
 
 enum OpenStatus {
     case Open(String)

--- a/Today Extension/LiteEvent.swift
+++ b/Today Extension/LiteEvent.swift
@@ -1,0 +1,32 @@
+//
+//  LiteEvent.swift
+//  Eatery
+//
+//  Created by Mark Bryan on 11/1/15.
+//  Copyright © 2015 CUAppDev. All rights reserved.
+//
+
+import UIKit
+import SwiftyJSON
+
+struct LiteEvent {
+    let startDate: NSDate
+    let startDateFormatted: String
+    
+    let endDate: NSDate
+    let endDateFormatted: String
+    
+    let desc: String
+    
+    init(json: JSON) {
+        desc = json["descr"].stringValue
+        startDate = NSDate(timeIntervalSince1970: json["startTimestamp"].doubleValue)
+        endDate   = NSDate(timeIntervalSince1970: json["endTimestamp"].doubleValue)
+        startDateFormatted = json["start"].stringValue
+        endDateFormatted = json["end"].stringValue
+    }
+    
+    func occurringOnDate(date: NSDate) -> Bool {
+        return startDate.compare(date) != .OrderedDescending && endDate.compare(date) != .OrderedAscending
+    }
+}

--- a/Today Extension/NoFavoritesTableViewCell.swift
+++ b/Today Extension/NoFavoritesTableViewCell.swift
@@ -1,0 +1,24 @@
+//
+//  NoFavoritesTableViewCell.swift
+//  Eatery
+//
+//  Created by Mark Bryan on 11/1/15.
+//  Copyright © 2015 CUAppDev. All rights reserved.
+//
+
+import UIKit
+
+class NoFavoritesTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+    
+}

--- a/Today Extension/NoFavoritesTableViewCell.xib
+++ b/Today Extension/NoFavoritesTableViewCell.xib
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="NoFavoritesTableViewCell" customModule="Today_Extension" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Favorites" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DhF-s8-cZe">
+                        <rect key="frame" x="111.5" y="10" width="97.5" height="23.5"/>
+                        <animations/>
+                        <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="17"/>
+                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <animations/>
+                <constraints>
+                    <constraint firstItem="DhF-s8-cZe" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="i1r-jm-kxh"/>
+                    <constraint firstItem="DhF-s8-cZe" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="jvU-Cf-rXo"/>
+                </constraints>
+            </tableViewCellContentView>
+            <animations/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Today Extension/TodayExtensionTableViewCell.swift
+++ b/Today Extension/TodayExtensionTableViewCell.swift
@@ -1,0 +1,43 @@
+//
+//  TodayExtensionTableViewCell.swift
+//  Eatery
+//
+//  Created by Mark Bryan on 11/1/15.
+//  Copyright © 2015 CUAppDev. All rights reserved.
+//
+
+import UIKit
+
+class TodayExtensionTableViewCell: UITableViewCell {
+    
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var hoursLabel: UILabel!
+    let circleView: CircleView
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.selectionStyle = UITableViewCellSelectionStyle.None
+        addSubview(circleView)
+    }
+    
+    override func layoutSubviews() {
+        let original = circleView.frame
+        circleView.frame = CGRect(x: CGRectGetMinX(original),
+            y: CGRectGetMidY(self.bounds) - CGRectGetHeight(original) / 2,
+            width: CGRectGetWidth(original), height: CGRectGetHeight(original))
+    }
+    
+    override func setSelected(selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+    
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        circleView = CircleView(frame: CGRect(x: 24, y: 16, width: 16, height: 16))
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        circleView = CircleView(frame: CGRect(x: 24, y: 16, width: 16, height: 16))
+        super.init(coder: aDecoder)
+    }
+}

--- a/Today Extension/TodayExtensionTableViewCell.xib
+++ b/Today Extension/TodayExtensionTableViewCell.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="69" id="KGk-i7-Jjw" customClass="TodayExtensionTableViewCell" customModule="Today_Extension" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="54"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="53.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hours" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P6w-hF-1kr">
+                        <rect key="frame" x="276" y="18" width="35.5" height="18"/>
+                        <animations/>
+                        <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="13"/>
+                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Eatery" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HjL-oW-w6R">
+                        <rect key="frame" x="57" y="16.5" width="43" height="20.5"/>
+                        <animations/>
+                        <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="15"/>
+                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <animations/>
+                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                <constraints>
+                    <constraint firstAttribute="trailingMargin" secondItem="P6w-hF-1kr" secondAttribute="trailing" constant="0.5" id="LPT-qA-Vrn"/>
+                    <constraint firstItem="HjL-oW-w6R" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="49" id="PRi-Lm-2M2"/>
+                    <constraint firstItem="HjL-oW-w6R" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="bWV-fC-0bg"/>
+                    <constraint firstItem="P6w-hF-1kr" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="xIX-k3-qam"/>
+                </constraints>
+            </tableViewCellContentView>
+            <animations/>
+            <connections>
+                <outlet property="hoursLabel" destination="P6w-hF-1kr" id="gMW-wh-MBs"/>
+                <outlet property="nameLabel" destination="HjL-oW-w6R" id="kr1-tD-28n"/>
+            </connections>
+            <point key="canvasLocation" x="450" y="377.5"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Today Extension/TodayExtensionTableViewController.swift
+++ b/Today Extension/TodayExtensionTableViewController.swift
@@ -1,0 +1,97 @@
+//
+//  TodayExtensionTableViewController.swift
+//  Eatery
+//
+//  Created by Mark Bryan on 11/1/15.
+//  Copyright © 2015 CUAppDev. All rights reserved.
+//
+
+import UIKit
+import NotificationCenter
+import SwiftyJSON
+
+class TodayExtensionTableViewController: UITableViewController, NCWidgetProviding {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem()
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithIdentifier("reuseIdentifier", forIndexPath: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
+        if editingStyle == .Delete {
+            // Delete the row from the data source
+            tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)
+        } else if editingStyle == .Insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(tableView: UITableView, moveRowAtIndexPath fromIndexPath: NSIndexPath, toIndexPath: NSIndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(tableView: UITableView, canMoveRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+        // Get the new view controller using segue.destinationViewController.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
Closes #53 

Created Today Extension with simplified LiteEatery and LiteEvent models to minimize cost of the extension. I had to reset to master and reimplement my work from the mark/today-widget branch because after rebasing with master on that branch, the branch got corrupted.

There's an issue with app groups that prevented me from fully implementing favorites (due to problems sharing favorites data from the main app to the extension via NSUserDefaults). However, the functionality for it is commented out in my changes on this branch so it can be easily integrated once this is fixed.

Currently, instead of listing favorites, the table view adds as many eateries (in order of fetching) and their hours descriptions until it reaches the max height for a table view in Notification Center.